### PR TITLE
Update Umami script URL to v2 version

### DIFF
--- a/application.py
+++ b/application.py
@@ -31,7 +31,7 @@ app.index_string = f"""
     <head>
         <script async defer
             data-website-id="81756657-16c3-439c-830a-4bc9d84514a4"
-            src="https://umami.snap.uaf.edu/umami.js"
+            src="https://umami.snap.uaf.edu/script.js"
             data-do-not-track="true"
             data-domains="snap.uaf.edu"
         >


### PR DESCRIPTION
This PR updates the Umami script URL to work with Umami v2. I.e., `umami.js` was changed to `script.js`.

You will need the Umami v2 Vagrant VM to test against. If you do not already have this set up, refer to the Vagrant instructions in https://github.com/ua-snap/nccwsc-projects/pull/154.

With the Vagrant VM running, and assuming Umami's port is forwarded to port 9999 of the host, simply change the Umami config in `application.py` to:

```
<script async defer
    data-website-id="81756657-16c3-439c-830a-4bc9d84514a4"
    src="http://localhost:9999/script.js"
    data-do-not-track="true"
>
```

Note that the `data-domains` attribute has been removed in the code above, for testing.

Then run this webapp locally and verify that your traffic shows up here: http://localhost:9999/websites/81756657-16c3-439c-830a-4bc9d84514a4